### PR TITLE
Add novalidate to d2l-input-text

### DIFF
--- a/src/components/award-icon-library.js
+++ b/src/components/award-icon-library.js
@@ -313,6 +313,7 @@ class AwardIconLibrary extends BaseMixin(LitElement) {
 				aria-haspopup="true"
 				aria-invalid=${!this.isValidIconName}
 				@input=${this._changedIconName}
+				novalidate
 				>
 			</d2l-input-text>
 			${!this.isValidIconName ? html`

--- a/src/components/awards-classlist-dialogs.js
+++ b/src/components/awards-classlist-dialogs.js
@@ -135,6 +135,7 @@ class AwardsClasslistIssueDialog extends BaseMixin(LitElement) {
 				aria-haspopup="true"
 				aria-invalid=${!this.isValidCriteria}
 				@input=${this._changeAwardCriteria}
+				novalidate
 				>
 			</d2l-input-text>
 			${!this.isValidCriteria ? html`
@@ -297,6 +298,7 @@ class AwardsClasslistRevokeDialog extends BaseMixin(LitElement) {
 				aria-haspopup="true"
 				aria-invalid=${!this.isValidReason}
 				@input=${this._changeRevokeReason}
+				novalidate
 				>
 			</d2l-input-text>
 

--- a/src/components/course-awards.js
+++ b/src/components/course-awards.js
@@ -302,6 +302,7 @@ class CourseAwards extends BaseMixin(LitElement) {
 					size=1
 					aria-invalid='${this.invalidCredits}'
 					@input='${this._handleInputChangedEvent}'
+					novalidate
 					>
 				</d2l-input-text>`;
 			if (this.invalidCredits) {


### PR DESCRIPTION
**Context:**
`d2l-input-text` is getting live validation so it can validate itself. To prevent this from impacting places that have their own validation we're adding `novalidate`. This will keep the behavior unchanged.